### PR TITLE
商品削除機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "faker"
   gem "gimei"
+  gem "pry-rails"
 end
 
 group :development do
@@ -87,3 +88,5 @@ gem "image_processing", "~> 1.2"
 gem "active_hash"
 
 gem "devise"
+
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.3)
     crass (1.0.6)
     date (3.3.4)
@@ -165,6 +166,11 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (5.1.2)
       stringio
     public_suffix (5.0.5)
@@ -300,16 +306,17 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  devise
   factory_bot_rails
   faker
-  image_processing (~> 1.2)
-  devise
   gimei
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   mini_magick
   mysql2 (~> 0.5)
   pg
+  pry-rails
   puma (~> 5.0)
   rails (~> 7.0.0)
   rspec-rails (~> 4.0.0)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
   # 商品一覧表示
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :find_item, only: [:show, :edit, :update]
-  before_action :correct_user, only: [:edit, :update]
+  before_action :find_item, only: [:show, :edit, :update, :destroy]
+  before_action :correct_user, only: [:edit, :update, :destroy]
 
 
 
@@ -15,11 +15,7 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
-  def destroy
-    item = Item.find(params[:id])
-    item.destroy
-    redirect_to root_path
-  end
+  
 
   # 商品個別表示
   def show
@@ -45,6 +41,14 @@ class ItemsController < ApplicationController
       redirect_to item_path
     else
       render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      render :show, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,6 +10,12 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+  end
+
   # 商品個別表示
   def show
     @item = Item.find(params[:id])

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", item_path(@item.id) , method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id) , data: { turbo_method: :delete }, class:"item-destroy" %>
       <% else %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id) , method: :delete, class:"item-destroy" %>
       <% else %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
# What
商品削除機能の実装
# Why
不要となった商品データを削除できるようにするため
# Gyazo
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/3c55979dd92efc3d0beef6aa5d0b106a